### PR TITLE
Add esmodules query parameter to optimise compilation of JavaScript

### DIFF
--- a/lib/create-bundle-file-js-bower.js
+++ b/lib/create-bundle-file-js-bower.js
@@ -7,9 +7,17 @@ const util = require("util");
 const promisify = util.promisify;
 const webpackConfig = require("./webpack-config-bower");
 
-module.exports = async ({ installationDirectory, entryFile, minify, ua }) => {
+module.exports = async ({
+	installationDirectory,
+	entryFile,
+	minify,
+	ua,
+	esmodules,
+}) => {
 	const targets = {};
-	if (ua) {
+	if (esmodules) {
+		targets.esmodules = true;
+	} else if (ua) {
 		const [name, version] = ua.split("/");
 		targets[name] = version;
 	}

--- a/lib/create-bundle-file-js-npm.js
+++ b/lib/create-bundle-file-js-npm.js
@@ -7,15 +7,28 @@ const util = require("util");
 const promisify = util.promisify;
 const webpackConfig = require("./webpack-config");
 
-module.exports = async ({ installationDirectory, entryFile, minify, ua }) => {
+module.exports = async ({
+	installationDirectory,
+	entryFile,
+	minify,
+	ua,
+	esmodules,
+}) => {
 	const targets = {};
-	if (ua) {
+	if (esmodules) {
+		targets.esmodules = true;
+	} else if (ua) {
 		const [name, version] = ua.split("/");
 		targets[name] = version;
 	}
 	const fs = new MemoryFS();
 	const compiler = webpack(
-		webpackConfig({ installationDirectory, entryFile, minify, targets }),
+		webpackConfig({
+			installationDirectory,
+			entryFile,
+			minify,
+			targets,
+		}),
 	);
 	compiler.outputFileSystem = fs;
 

--- a/lib/generate-js-bundle-bower.js
+++ b/lib/generate-js-bundle-bower.js
@@ -6,7 +6,7 @@ const createEntryFile = require("./create-entry-file-js-bower");
 const createBundleFile = require("./create-bundle-file-js-bower");
 const deleteDirectory = require("./delete-directory");
 
-module.exports = async ({ modules, minify, ua }) => {
+module.exports = async ({ modules, minify, ua, esmodules }) => {
 	// createTemporaryDirectory
 	const installationDirectory = await createTemporaryDirectory();
 	// installModules
@@ -32,6 +32,7 @@ module.exports = async ({ modules, minify, ua }) => {
 		entryFile,
 		minify,
 		ua,
+		esmodules,
 	});
 
 	// deleteDirectory

--- a/lib/generate-js-bundle-npm.js
+++ b/lib/generate-js-bundle-npm.js
@@ -6,7 +6,7 @@ const createEntryFile = require("./create-entry-file-js-npm");
 const createBundleFile = require("./create-bundle-file-js-npm");
 const deleteDirectory = require("./delete-directory");
 
-module.exports = async ({ modules, minify, ua }) => {
+module.exports = async ({ modules, minify, ua, esmodules }) => {
 	// createTemporaryDirectory
 	const installationDirectory = await createTemporaryDirectory();
 	// installModules
@@ -32,6 +32,7 @@ module.exports = async ({ modules, minify, ua }) => {
 		entryFile,
 		minify,
 		ua,
+		esmodules,
 	});
 
 	// deleteDirectory

--- a/lib/middleware/sanitise-esmodules-parameter.js
+++ b/lib/middleware/sanitise-esmodules-parameter.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const httpError = require("http-errors");
+
+/**
+ * Middleware used to ensure the esmodules query parameter is either `on` or `off`.
+ *
+ * If esmodules parameter is a valid value, move on to the next middleware.
+ * If esmodules parameter is not valid, return an HTTP 400 status code.
+ */
+module.exports = (request, response, next) => {
+	if (request.query.esmodules) {
+		if (request.query.esmodules === "") {
+			next(httpError(400, "The esmodules query parameter can not be empty."));
+		} else if (!/^(on|off)$/.test(request.query.esmodules)) {
+			next(
+				httpError(
+					400,
+					"The esmodules query parameter can only be `on` or `off`.",
+				),
+			);
+		} else {
+			next();
+		}
+	} else {
+		request.query.esmodules = "off";
+		next();
+	}
+};

--- a/lib/routes/v3/bundles/js.js
+++ b/lib/routes/v3/bundles/js.js
@@ -17,6 +17,7 @@ module.exports = async function(req, res, next) {
 					modules: req.query.modules.split(","),
 					minify: req.query.minify,
 					ua: req.query.ua,
+					esmodules: req.query.esmodules === "on",
 				});
 				break;
 			}
@@ -25,6 +26,7 @@ module.exports = async function(req, res, next) {
 					modules: req.query.modules.split(","),
 					minify: req.query.minify,
 					ua: req.query.ua,
+					esmodules: req.query.esmodules === "on",
 				});
 				break;
 			}

--- a/lib/service.js
+++ b/lib/service.js
@@ -3,6 +3,7 @@
 const origamiService = require("@financial-times/origami-service");
 const healthChecks = require("./health-checks");
 const sanitiseModulesParameter = require("./middleware/sanitise-modules-parameter");
+const sanitiseEsmodulesParameter = require("./middleware/sanitise-esmodules-parameter");
 const sanitiseMinifyParameter = require("./middleware/sanitise-minify-parameter");
 const sanitiseRegistryParameter = require("./middleware/sanitise-registry-parameter");
 const sanitiseUaParameter = require("./middleware/sanitise-ua-parameter");
@@ -44,6 +45,7 @@ function mountRoutes(app) {
 		sanitiseRegistryParameter,
 		sanitiseMinifyParameter,
 		sanitiseModulesParameter,
+		sanitiseEsmodulesParameter,
 		sanitiseUaParameter,
 		require("./routes/v3/bundles/js"),
 	);

--- a/test/integration/v3/bundles/js.test.js
+++ b/test/integration/v3/bundles/js.test.js
@@ -76,6 +76,30 @@ describe("/v3/bundles/js", function() {
 		});
 	});
 
+	context("invalid esmodules parameter", function() {
+		it("GET /v3/bundles/js?esmodules", function() {
+			return request(app)
+				.get("/v3/bundles/js?esmodules")
+				.expect(400)
+				.expect("Content-Type", "text/html; charset=utf-8")
+				.expect(
+					"cache-control",
+					"max-age=0, must-revalidate, no-cache, no-store",
+				);
+		});
+
+		it("GET /v3/bundles/js?esmodules=carrot", function() {
+			return request(app)
+				.get("/v3/bundles/js?esmodules=carrot")
+				.expect(400)
+				.expect("Content-Type", "text/html; charset=utf-8")
+				.expect(
+					"cache-control",
+					"max-age=0, must-revalidate, no-cache, no-store",
+				);
+		});
+	});
+
 	context("invalid registry parameter", function() {
 		it("returns an error", function() {
 			return request(app)
@@ -430,6 +454,58 @@ describe("/v3/bundles/js", function() {
 							proclaim.isTrue(
 								isES6(response.text),
 								"expected JavaScript response to be valid ECMAScript 6 syntax but it was not.",
+							);
+						});
+					// .expect("etag", "a7c4c23840cef2aa78288a6b32027b0d");
+				});
+			},
+		);
+
+		context(
+			"compiles the JavaScript based upon the esmodules query parameter",
+			function() {
+				it("compiles to ES6 when esmodules query parameter is set to `on`", function() {
+					return request(app)
+						.get(
+							"/v3/bundles/js?modules=@financial-times/o-test-component@1.0.29-test&source=test&minify=off&esmodules=on&registry=npm",
+						)
+						.expect(response => {
+							proclaim.isFalse(
+								isES5(response.text),
+								"expected JavaScript response to not be valid ECMAScript 5 syntax but it was.",
+							);
+							proclaim.isTrue(
+								isES7(response.text),
+								"expected JavaScript response to be valid ECMAScript 7 syntax but it was not.",
+							);
+						});
+					// .expect("etag", "a7c4c23840cef2aa78288a6b32027b0d");
+				});
+
+				it("compiles based upon user-agent header if esmodules query parameter is set to `off`", function() {
+					return request(app)
+						.get(
+							"/v3/bundles/js?modules=@financial-times/o-test-component@1.0.29-test&source=test&minify=off&esmodules=off&registry=npm",
+						)
+						.set("User-Agent", "unknown_browser/1")
+						.expect(response => {
+							proclaim.isTrue(
+								isES5(response.text),
+								"expected JavaScript response to be valid ECMAScript 5 syntax but it was not.",
+							);
+						});
+					// .expect("etag", "a7c4c23840cef2aa78288a6b32027b0d");
+				});
+
+				it("compiles based upon ua query parameter if esmodules query parameter is set to `off`", function() {
+					return request(app)
+						.get(
+							"/v3/bundles/js?modules=@financial-times/o-test-component@1.0.29-test&source=test&minify=off&esmodules=off&registry=npm&ua=unknown_browser/1",
+						)
+						.expect(response => {
+							proclaim.isTrue(
+								isES5(response.text),
+								"expected JavaScript response to be valid ECMAScript 5 syntax but it was not.",
 							);
 						});
 					// .expect("etag", "a7c4c23840cef2aa78288a6b32027b0d");
@@ -896,6 +972,58 @@ describe("/v3/bundles/js", function() {
 							proclaim.isTrue(
 								isES6(response.text),
 								"expected JavaScript response to be valid ECMAScript 6 syntax but it was not.",
+							);
+						});
+					// .expect("etag", "a7c4c23840cef2aa78288a6b32027b0d");
+				});
+			},
+		);
+
+		context(
+			"compiles the JavaScript based upon the esmodules query parameter",
+			function() {
+				it("compiles to ES6 when esmodules query parameter is set to `on`", function() {
+					return request(app)
+						.get(
+							"/v3/bundles/js?modules=o-test-component@1.0.29&source=test&minify=off&esmodules=on",
+						)
+						.expect(response => {
+							proclaim.isFalse(
+								isES5(response.text),
+								"expected JavaScript response to not be valid ECMAScript 5 syntax but it was.",
+							);
+							proclaim.isTrue(
+								isES7(response.text),
+								"expected JavaScript response to be valid ECMAScript 7 syntax but it was not.",
+							);
+						});
+					// .expect("etag", "a7c4c23840cef2aa78288a6b32027b0d");
+				});
+
+				it("compiles based upon user-agent header if esmodules query parameter is set to `off`", function() {
+					return request(app)
+						.get(
+							"/v3/bundles/js?modules=o-test-component@1.0.29&source=test&minify=off&esmodules=off",
+						)
+						.set("User-Agent", "unknown_browser/1")
+						.expect(response => {
+							proclaim.isTrue(
+								isES5(response.text),
+								"expected JavaScript response to be valid ECMAScript 5 syntax but it was not.",
+							);
+						});
+					// .expect("etag", "a7c4c23840cef2aa78288a6b32027b0d");
+				});
+
+				it("compiles based upon ua query parameter if esmodules query parameter is set to `off`", function() {
+					return request(app)
+						.get(
+							"/v3/bundles/js?modules=o-test-component@1.0.29&source=test&minify=off&esmodules=off&ua=unknown_browser/1",
+						)
+						.expect(response => {
+							proclaim.isTrue(
+								isES5(response.text),
+								"expected JavaScript response to be valid ECMAScript 5 syntax but it was not.",
 							);
 						});
 					// .expect("etag", "a7c4c23840cef2aa78288a6b32027b0d");


### PR DESCRIPTION
for browsers which support ECMAScript Modules. Note that this does not output an ECMAScript Module, it still outputs a UMD module as Webpack does not yet support outputting an ECMAScript Module